### PR TITLE
circleci: Fix op-scim-bridge dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,7 @@ jobs:
             git checkout gh-pages
             git merge release  --no-edit
             helm init --client-only
+            helm dependency update op-scim-bridge
             helm package kube-iptables-tailer -d packages
             helm package awx -d packages
             helm package squid -d packages


### PR DESCRIPTION
Forgot to get dependencies before packaging :) 