### PR TITLE
Add label for service selector and add deployment tolerations

### DIFF
--- a/awx/templates/deployment-task.yaml
+++ b/awx/templates/deployment-task.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "awx.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: task
     spec:
       containers:
         - name: task
@@ -62,6 +63,8 @@ spec:
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+{{- toYaml .Values.tolerations | nindent 8 }}
     {{- end }}
       volumes:
         - name: {{ include "awx.fullname" . }}-application-config

--- a/awx/templates/deployment-web.yaml
+++ b/awx/templates/deployment-web.yaml
@@ -27,6 +27,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "awx.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: web
     spec:
       containers:
         - name: web
@@ -71,6 +72,8 @@ spec:
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+      tolerations:
+{{- toYaml .Values.tolerations | nindent 8 }}
     {{- end }}
       volumes:
         - name: {{ include "awx.fullname" . }}-application-config


### PR DESCRIPTION
awx-web service has this selector:

```
  selector:
    app.kubernetes.io/name: {{ include "awx.name" . }}
    app.kubernetes.io/component: web
    app.kubernetes.io/instance: {{ .Release.Name }}
```
but the awx-web deployment is lacking necessary label which is the `app.kubernetes.io/component: web` part

awx-task and awx-web deployment template needs to be added with additional label `app.kubernetes.io/component: task` and `app.kubernetes.io/component: web` respectively, so the service can point to the pod

Also, the tolerations values need to be added to the template