### PR TITLE
Added priorityClassName to daemonset

### DIFF
--- a/kube-iptables-tailer/Chart.yaml
+++ b/kube-iptables-tailer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.1.0"
 description: A Helm chart for Kubernetes
 name: kube-iptables-tailer
-version: 0.1.2
+version: 0.1.3
 home: https://github.com/honestica/lifen-charts
 keywords:
 - kube-iptables-tailer

--- a/kube-iptables-tailer/templates/daemonset.yaml
+++ b/kube-iptables-tailer/templates/daemonset.yaml
@@ -25,6 +25,9 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ template "kube-iptables-tailer.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/kube-iptables-tailer/values-eks.yaml
+++ b/kube-iptables-tailer/values-eks.yaml
@@ -6,6 +6,12 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+# Specify to use specific priorityClass for pods
+# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority
+# Pods to make scheduling of the pending Pod possible.
+priorityClassName: ""
+
 # Only one of the next configuration should be enabled
 # iptablesLogPath: "/var/log/iptables.log"
 journalDirectory: "/var/log/journal"

--- a/kube-iptables-tailer/values.yaml
+++ b/kube-iptables-tailer/values.yaml
@@ -3,6 +3,12 @@ image:
   tag: master-19
   pullPolicy: IfNotPresent
 
+# Specify to use specific priorityClass for pods
+# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# If a Pod cannot be scheduled, the scheduler tries to preempt (evict) lower priority
+# Pods to make scheduling of the pending Pod possible.
+priorityClassName: ""
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
Added priorityClassName field to daemonset. This is useful to ensure logging pods take priority when scheduling

Signed-off-by: Tom Bartlett <tom.bartlett@spire.com>