### PR TITLE
Add PodSecurityPoliciy to kube-iptables-tailer chart.

### DIFF
--- a/kube-iptables-tailer/Chart.yaml
+++ b/kube-iptables-tailer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.1.0"
 description: A Helm chart for Kubernetes
 name: kube-iptables-tailer
-version: 0.1.5
+version: 0.1.6
 home: https://github.com/honestica/lifen-charts
 keywords:
 - kube-iptables-tailer

--- a/kube-iptables-tailer/templates/clusterrole.yaml
+++ b/kube-iptables-tailer/templates/clusterrole.yaml
@@ -15,4 +15,11 @@ rules:
 - apiGroups: [""]
   resources: ["events"]
   verbs:     ["patch","create"]
+{{- if .Values.rbac.pspEnabled }}
+- apiGroups: ["policy"]
+  resources: ["podsecuritypolicies"]
+  verbs:     ["use"]
+  resourceNames:
+  - {{ include "kube-iptables-tailer.fullname" . }}
+{{- end }}
 {{- end -}}

--- a/kube-iptables-tailer/templates/podsecuritypolicy.yaml
+++ b/kube-iptables-tailer/templates/podsecuritypolicy.yaml
@@ -1,0 +1,37 @@
+{{- if and .Values.rbac.create .Values.rbac.pspEnabled -}}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ include "kube-iptables-tailer.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-iptables-tailer.name" . }}
+    helm.sh/chart: {{ include "kube-iptables-tailer.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+  - ALL
+  volumes:
+  - "emptyDir"
+  - "secret"
+  - "hostPath"
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: "RunAsAny"
+  seLinux:
+    rule: "RunAsAny"
+  supplementalGroups:
+    rule: "MustRunAs"
+    ranges:
+      - min: 0
+        max: 65535
+  fsGroup:
+    rule: "MustRunAs"
+    ranges:
+      - min: 0
+        max: 65535
+{{- end -}}

--- a/kube-iptables-tailer/values-eks.yaml
+++ b/kube-iptables-tailer/values-eks.yaml
@@ -31,6 +31,7 @@ podAnnotations: {}
 
 rbac:
   create: true
+  pspEnabled: true
 
 serviceAccount:
   create: true

--- a/kube-iptables-tailer/values.yaml
+++ b/kube-iptables-tailer/values.yaml
@@ -25,6 +25,7 @@ podAnnotations: {}
 
 rbac:
   create: true
+  pspEnabled: true
 
 serviceAccount:
   create: true


### PR DESCRIPTION
This PR adds a `PodSecurityPolicy` to the deployment of `kube-iptables-tailer` when enabled.

Tested on Kubespray/Flatcar Linux/Calico.