### PR TITLE
Add 'app' label to looker resources

### DIFF
--- a/looker/templates/_helpers.tpl
+++ b/looker/templates/_helpers.tpl
@@ -35,6 +35,7 @@ Common labels
 */}}
 {{- define "looker.labels" -}}
 helm.sh/chart: {{ include "looker.chart" . }}
+app: {{ template "looker.name" . }}
 {{ include "looker.selectorLabels" . }}
 {{- if .Chart.AppVersion }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}


### PR DESCRIPTION
This PR adds a "app" label to looker resources, so that we're consistent with other charts
in this repo and we can identify looker k8s resources easily.
