### PR TITLE
Add optional syslog sidecar container

### DIFF
--- a/kube-iptables-tailer/Chart.yaml
+++ b/kube-iptables-tailer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.1.0"
 description: A Helm chart for Kubernetes
 name: kube-iptables-tailer
-version: 0.1.6
+version: 0.2.0
 home: https://github.com/honestica/lifen-charts
 keywords:
 - kube-iptables-tailer

--- a/kube-iptables-tailer/templates/configmap.yaml
+++ b/kube-iptables-tailer/templates/configmap.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.syslogSidecar.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "kube-iptables-tailer.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "kube-iptables-tailer.name" . }}
+    helm.sh/chart: {{ include "kube-iptables-tailer.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+data:
+  rsyslog.conf: |
+    module(load="imklog" ParseKernelTimestamp="on" KeepKernelTimestamp="off")
+    template(name="traditional_with_rfc3339" type="string" string="%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogtag%%msg:::sp-if-no-1st-sp%%msg:::drop-last-lf%\n")
+    $FileOwner rsyslog
+    $FileGroup rsyslog
+    $FileCreateMode 0640
+    $DirCreateMode 0755
+    $Umask 0022
+    $WorkDirectory /work
+    # drop everything that's not calico-packet
+    :msg, !startswith, " calico-packet:" ~
+    kern.* -/logs/kernel.log;traditional_with_rfc3339
+{{- end }}

--- a/kube-iptables-tailer/templates/daemonset.yaml
+++ b/kube-iptables-tailer/templates/daemonset.yaml
@@ -57,6 +57,11 @@ spec:
           {{- if .Values.packetDropLogTimeLayout }}
             - name: "PACKET_DROP_LOG_TIME_LAYOUT"
               value: "{{ .Values.packetDropLogTimeLayout }}"
+          {{- else }}
+          {{- if .Values.syslogSidecar.enabled }}
+            - name: "PACKET_DROP_LOG_TIME_LAYOUT"
+              value: "2006-01-02T15:04:05Z07:00"
+          {{- end }}
           {{- end }}
           {{- if .Values.logTimeRegex }}
             - name: "LOG_TIME_REGEX"
@@ -70,11 +75,42 @@ spec:
               mountPath: "/my-service-logs"
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+        {{- if .Values.syslogSidecar.enabled }}
+        - name: syslog
+          image: {{ .Values.syslogSidecar.image }}:{{ .Values.syslogSidecar.tag }}
+          env:
+          - name: RSYSLOG_CONF
+            value: /rsyslog-conf/rsyslog.conf
+          securityContext:
+            capabilities:
+              add: ["SYSLOG"]
+          volumeMounts:
+          - name: config
+            mountPath: /config
+          - name: rsyslog-conf
+            mountPath: /rsyslog-conf
+          - name: "iptables-logs"
+            mountPath: /logs
+          - name: work
+            mountPath: /work
+        {{- end }}
       volumes:
+        {{- if not .Values.syslogSidecar.enabled }}
         - name: "iptables-logs"
           hostPath:
             # absolute path of the directory containing iptables log file on your host
             path: "/var/log"
+        {{- else }}
+        - name: rsyslog-conf
+          configMap:
+            name: {{ include "kube-iptables-tailer.fullname" . }}
+        - name: config
+          emptyDir: {}
+        - name: iptables-logs
+          emptyDir: {}
+        - name: work
+          emptyDir: {}
+        {{- end }}
         - name: "service-logs"
           emptyDir: {}
       {{- with .Values.nodeSelector }}

--- a/kube-iptables-tailer/values-syslogsidecar.yaml
+++ b/kube-iptables-tailer/values-syslogsidecar.yaml
@@ -13,7 +13,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Only one of the next configuration should be enabled
-# iptablesLogPath: "/var/log/iptables.log"
+iptablesLogPath: "/var/log/kernel.log"
 # journalDirectory: "/var/log/journal"
 
 iptablesLogPrefix: "calico-packet:"
@@ -56,6 +56,6 @@ tolerations: []
 affinity: {}
 
 syslogSidecar:
-  enabled: false
+  enabled: true
   image: rsyslog/syslog_appliance_alpine
   tag: latest


### PR DESCRIPTION
On some operating systems, such as Talos, there are no accessible logs in a traditional matter. Adding an optional syslog sidecar makes kube-iptables-tailer work on those systems.