### PR TITLE
Optionally mount a configuration secret into the Squid container

### DIFF
--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             subPath: squid.conf
           - name: cache
             mountPath: /var/cache/squid
+        {{- if .Values.configSecret }}
+          - name: config
+            mountPath: /etc/squid/config
+        {{- end }}
         # Load the configuration files for nginx
           livenessProbe:
             tcpSocket:
@@ -110,6 +114,11 @@ spec:
           name: {{ template "squid.fullname" . }}-conf
       - emptyDir: {}
         name: cache
+    {{- if .Values.configSecret }}
+      - name: config
+        secret:
+          secretName: {{ .Values.configSecret }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -75,6 +75,8 @@ config: |
   # Do not display squid version
   httpd_suppress_version_string on
 
+# Optionally specify a secret whose contents will be mounted into /etc/squid/config.
+# configSecret: config-example
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This is useful when you have additional files like an NCSA credentials file that you want to reference in your Squid configuration. Just create a secret:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: config
data:
  users: <base64-data>
```
Then, reference it in your Helm release values using the new `configSecret` key:
```yaml
configSecret: config
config: |
  auth_param basic program /usr/lib/squid/basic_ncsa_auth /etc/squid/config/users
  auth_param basic children 5
  auth_param basic credentialsttl 1 minute

  acl auth proxy_auth REQUIRED
  http_access deny !auth
  http_access allow auth
  http_access deny all
  ...
```
I chose to go with a very simple approach here, but there are certainly more advanced/flexible routes that could be taken in the chart, e.g. allowing the specification of a list of volumes to mount into the Squid container, which would also support ConfigMaps.