### PR TITLE
[external contrib] Optionally mount a configuration secret into the Squid container

### DIFF
--- a/squid/Chart.yaml
+++ b/squid/Chart.yaml
@@ -15,4 +15,4 @@ maintainers:
 sources:
 - https://github.com/squid-cache/squid
 
-version: 0.3.0
+version: 0.4.0

--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
           - name: cache
             mountPath: /var/cache/squid
         {{- if .Values.configSecret }}
-          - name: config
+          - name: configSecret
             mountPath: /etc/squid/config
         {{- end }}
         # Load the configuration files for nginx
@@ -71,7 +71,7 @@ spec:
             tcpSocket:
               port: 3128
             initialDelaySeconds: 5
-            periodSeconds: 10 
+            periodSeconds: 10
           readinessProbe:
             tcpSocket:
               port: 3128
@@ -115,7 +115,7 @@ spec:
       - emptyDir: {}
         name: cache
     {{- if .Values.configSecret }}
-      - name: config
+      - name: configSecret
         secret:
           secretName: {{ .Values.configSecret }}
     {{- end }}

--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -62,6 +62,10 @@ spec:
             subPath: squid.conf
           - name: cache
             mountPath: /var/cache/squid
+        {{- if .Values.configSecret }}
+          - name: config
+            mountPath: /etc/squid/config
+        {{- end }}
         # Load the configuration files for nginx
           livenessProbe:
             tcpSocket:
@@ -110,6 +114,11 @@ spec:
           name: {{ template "squid.fullname" . }}-conf
       - emptyDir: {}
         name: cache
+    {{- if .Values.configSecret }}
+      - name: config
+        secret:
+          secretName: {{ .Values.configSecret }}
+    {{- end }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -75,6 +75,8 @@ config: |
   # Do not display squid version
   httpd_suppress_version_string on
 
+# Optionally specify a secret whose contents will be mounted into /etc/squid/config.
+# configSecret: config-example
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
cf https://github.com/honestica/lifen-charts/pull/61

Bump chart version + small naming improvment