### PR TITLE
Add extraArgs, extraVolumeMounts and extraVolumes

### DIFF
--- a/kube-iptables-tailer/Chart.yaml
+++ b/kube-iptables-tailer/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "v0.1.0"
 description: A Helm chart for Kubernetes
 name: kube-iptables-tailer
-version: 0.2.1
+version: 0.2.2
 home: https://github.com/honestica/lifen-charts
 keywords:
 - kube-iptables-tailer

--- a/kube-iptables-tailer/templates/daemonset.yaml
+++ b/kube-iptables-tailer/templates/daemonset.yaml
@@ -44,8 +44,9 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - "/kube-iptables-tailer"
-            - "--log_dir=/my-service-logs" # change the output directory of service logs
-            - "--v=4" # enable V-leveled logging at this level
+            {{- with .Values.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           env:
           {{- if .Values.iptablesLogPath }}
             - name: "IPTABLES_LOG_PATH"
@@ -77,28 +78,32 @@ spec:
             - name: "iptables-logs"
               mountPath: "/var/log"
               readOnly: true
-            - name: "service-logs"
-              mountPath: "/my-service-logs"
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
         {{- if .Values.syslogSidecar.enabled }}
         - name: syslog
           image: {{ .Values.syslogSidecar.image }}:{{ .Values.syslogSidecar.tag }}
           env:
-          - name: RSYSLOG_CONF
-            value: /rsyslog-conf/rsyslog.conf
+            - name: RSYSLOG_CONF
+              value: /rsyslog-conf/rsyslog.conf
           securityContext:
             capabilities:
               add: ["SYSLOG"]
           volumeMounts:
-          - name: config
-            mountPath: /config
-          - name: rsyslog-conf
-            mountPath: /rsyslog-conf
-          - name: "iptables-logs"
-            mountPath: /logs
-          - name: work
-            mountPath: /work
+            - name: config
+              mountPath: /config
+            - name: rsyslog-conf
+              mountPath: /rsyslog-conf
+            - name: "iptables-logs"
+              mountPath: /logs
+            - name: work
+              mountPath: /work
+            {{- if .Values.extraVolumeMounts }}
+            {{- toYaml .Values.extraVolumeMounts | nindent 12 }}
+            {{- end }}
         {{- end }}
       volumes:
         {{- if not .Values.syslogSidecar.enabled }}
@@ -117,8 +122,9 @@ spec:
         - name: work
           emptyDir: {}
         {{- end }}
-        - name: "service-logs"
-          emptyDir: {}
+        {{- if .Values.extraVolumes }}
+        {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/kube-iptables-tailer/values.yaml
+++ b/kube-iptables-tailer/values.yaml
@@ -61,7 +61,17 @@ tolerations: []
 
 affinity: {}
 
+extraArgs: []
+
 syslogSidecar:
   enabled: false
   image: rsyslog/syslog_appliance_alpine
   tag: latest
+
+# extraVolumes and extraVolumeMounts allows you to mount other volumes
+extraVolumes: []
+#  - name: service-logs
+#    emptyDir: {}
+extraVolumeMounts: []
+#  - name: service-logs
+#    mountPath: /my-service-logs


### PR DESCRIPTION
In https://github.com/box/kube-iptables-tailer/commit/e683b8a0c169453884d98b6a54eb63e9720e68ef logging was rewritten, removing the flags `--log_dir` and `--v`.

This PR removes these hardcoded flags, and adds options to specify `extraArgs`, `extraVolumeMounts` and `extraVolumes` to enable the same when running an old version of the kube-iptables-tailer container.