### PR TITLE
Fix(squid): Ingress API Version

### DIFF
--- a/squid/templates/_helpers.tpl
+++ b/squid/templates/_helpers.tpl
@@ -30,3 +30,18 @@ Create chart name and version as used by the chart label.
 {{- define "squid.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Return the appropriate apiVersion for ingress
+*/}}
+{{- define "squid.ingress.apiVersion" -}}
+{{- if .Values.apiVersionOverrides.ingress -}}
+{{- print .Values.apiVersionOverrides.ingress -}}
+{{- else if semverCompare "<1.14-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion) -}}
+{{- print "extensions/v1beta1" -}}
+{{- else if semverCompare "<1.19-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion) -}}
+{{- print "networking.k8s.io/v1beta1" -}}
+{{- else -}}
+{{- print "networking.k8s.io/v1" -}}
+{{- end -}}
+{{- end -}}

--- a/squid/templates/ingress.yaml
+++ b/squid/templates/ingress.yaml
@@ -1,11 +1,8 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "squid.fullname" . -}}
 {{- $ingressPath := .Values.ingress.path -}}
-{{- if (semverCompare ">=1.14-0" (substr 1 -1 .Capabilities.KubeVersion.GitVersion)) }}
-apiVersion: networking.k8s.io/v1beta1
-{{- else }}
-apiVersion: extensions/v1beta1
-{{- end }}
+{{- $ingressPathType := .Values.ingress.pathType -}}
+apiVersion: {{ include "squid.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -35,8 +32,18 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
+            {{- if eq (include "squid.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+            pathType: {{ $ingressPathType }}
+            {{- end }}
             backend:
+            {{- if eq (include "squid.ingress.apiVersion" $) "networking.k8s.io/v1" }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  name: http
+            {{- else }}
               serviceName: {{ $fullName }}
               servicePort: http
+            {{- end }}
   {{- end }}
 {{- end }}

--- a/squid/values.yaml
+++ b/squid/values.yaml
@@ -4,6 +4,10 @@
 
 replicaCount: 1
 
+apiVersionOverrides: {}
+## Override ingress api auto detection:
+#  ingress: networking.k8s.io/v1
+
 image:
   repository: honestica/squid
   tag: 4-ff434982-c47b-47c3-b705-b2adb2730978
@@ -25,6 +29,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
+  pathType: Prefix
   hosts:
     - chart-example.local
   tls: []


### PR DESCRIPTION
Hi,

this is a fix for ingress controller in squid, when using k8s version > 1.19

