### PR TITLE
[k8s-1.22] update lifen public helm charts to k8s 1.22

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,8 @@ jobs:
       HELM_VERSION: 3.8.2
       KUBEVAL_VERSION: v0.16.1
       CONFTEST_VERSION: 0.27.0
-      K8S_VERSIONS: 1.22.9 1.21.4 1.20.10
-      KUBECTL_VERSION: v1.22.8
+      K8S_VERSIONS: 1.22.10 1.21.4 1.20.10
+      KUBECTL_VERSION: v1.22.10
       KUBECONFIG: /home/circleci/.kube/config
       MINIKUBE_VERSION: v1.25.2
       MINIKUBE_HOME: /home/circleci

--- a/looker/Chart.yaml
+++ b/looker/Chart.yaml
@@ -4,7 +4,7 @@ home: https://github.com/honestica/lifen-charts
 description: A Looker Helm chart for Kubernetes.
 icon: https://looker.com/assets/img/images/logos/looker.svg
 # type: application
-version: 0.1.2
+version: 0.1.3
 keywords:
 - looker
 - google

--- a/looker/templates/ingress-api.yaml
+++ b/looker/templates/ingress-api.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingressApi.enabled -}}
 {{- $fullName := include "looker.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}-api

--- a/looker/templates/ingress.yaml
+++ b/looker/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "looker.fullname" . -}}
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}


### PR DESCRIPTION
Removed all removed API versions from public helm chart to prepare to be compatible with k8s 1.22

JIRA reference: https://honestica.atlassian.net/browse/INFRABUILD-2579