### PR TITLE
fix: mount additional config files to init-container

### DIFF
--- a/squid/templates/deployment.yaml
+++ b/squid/templates/deployment.yaml
@@ -39,6 +39,10 @@ spec:
             subPath: squid.conf
           - name: cache
             mountPath: /var/cache/squid
+          {{- if .Values.configSecret }}
+          - name: config-secret
+            mountPath: /etc/squid/config
+          {{- end }}
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
In order to reference additional config files with the `include <path to file>` statement from the base config, the secret also has to be mounted into the init-container. Otherwise the init-container fails with:
```
FATAL: Unable to find configuration file: /etc/squid/config/<filename>: (2) No such file or directory
```