### PR TITLE
looker: prepare for Kubernetes 1.25

### DIFF
--- a/looker/Chart.yaml
+++ b/looker/Chart.yaml
@@ -4,7 +4,7 @@ home: https://github.com/honestica/lifen-charts
 description: A Looker Helm chart for Kubernetes.
 icon: https://looker.com/assets/img/images/logos/looker.svg
 # type: application
-version: 0.1.3
+version: 0.2.0
 keywords:
 - looker
 - google

--- a/looker/templates/hpa.yaml
+++ b/looker/templates/hpa.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.autoscaling.enabled }}
-apiVersion: autoscaling/v2beta1
+{{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
+apiVersion: autoscaling/v2
+{{- else }}
+apiVersion: autoscaling/v2beta2
+{{- end }}
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "looker.fullname" . }}
@@ -17,12 +21,24 @@ spec:
     - type: Resource
       resource:
         name: cpu
+        {{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+        {{- end }}
     {{- end }}
     {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
+        {{- if .Capabilities.APIVersions.Has "autoscaling/v2/HorizontalPodAutoscaler" }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- else }}
         targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+        {{- end }}
     {{- end }}
 {{- end }}


### PR DESCRIPTION
Update looker chart to be compatible with Kubernetes 1.25 (some deprecated API were removed)