### PR TITLE
Close stales PR with Github Action

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,9 @@
+name: Stale worklow
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 23 */2 * *' # Every 2 day at 23h
+
+jobs:
+  build:
+    uses: honestica/.github/.github/workflows/stale.yml@master


### PR DESCRIPTION
We want to avoid having stale PR on all Honestica repositories. For that we will use the stale PR action from Github.