### PR TITLE
[looker][aws eks] pod failing to due connection to localhost:8081 

### DIFF
--- a/looker/README.md
+++ b/looker/README.md
@@ -1,4 +1,4 @@
-# Looker
+# Lookerr
 
 Looker is a cloud-based business intelligence (BI) platform designed to explore and analyze data.
 


### PR DESCRIPTION
Hello @gbenchoukalifen @ylascombe @marcmillien @rroufa @fpoussin @rroufa @danports @robinelfrink @jonkerj @jeanlucmongrain @ckotzbauer 

I'm trying to deploy looker, version 25.0.27, on aws eks, using helm chart.
The pod is failing due to connection to localhost:8081.
I don't have this por defined anywhere. It is allowed in eks security group. Also, tried to override it in lookerstart.cfg with LOOKERARGS= --port=9998, but the error remains.
Do you have any idea about this? Thanks.

```
{"msg":"Loaded and resolved feature flags configuration files for environment: production","h":"looker-74c8f9446d-c8tw8","n":"<retrieving from license>","nid":null,"t":"2025-02-10T16:30:11.060Z","s":"INFO","rid":"00fa4","c":"configuration"}
{"msg":"configurationManager registers HttpConfigurationSource on endpoint http://localhost:8081/config","h":"looker-74c8f9446d-c8tw8","n":"<retrieving from license>","nid":null,"t":"2025-02-10T16:30:11.166Z","s":"INFO","rid":"00fa4","c":"configuration"}

{"msg":"Failed to refresh configuration from source: HttpConfigurationSource, error: Connect to localhost:8081 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused)","h":"looker-74c8f9446d-c8tw8","n":"<retrieving from license>","nid":null,"t":"2025-02-10T16:30:11.586Z","s":"WARN","rid":"00fa4","c":"configuration"}
```

Best regards,
Luís Costa